### PR TITLE
Set postscriptIsFixedPitch flag in UFO format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ Inconsolata-LGC-BoldItalic.mk: Inconsolata-LGC.mk
 .sfd.ufo:
 	for i in $?;do fontforge -lang=ff -c "Open(\"$$i\");Generate(\"$@\");Close()";done
 	grep "^Version: " Inconsolata-LGC.sfd | sed -e "s/^Version: //"
-	sed -i~ -e "/<key>openTypeNameVersion<\/key>/ { n; s/<string>.*<\/string>/<string>$$(grep "^Version: " $< | sed -e "s/^Version: //")<\/string>/; }" $@/fontinfo.plist
+	sed -i~ -e "/<key>openTypeNameVersion<\/key>/ { n; s/<string>.*<\/string>/<string>$$(grep "^Version: " $< | sed -e "s/^Version: //")<\/string><key>postscriptIsFixedPitch<\/key><true\/>/; }" $@/fontinfo.plist
 
 .PHONY: ttf otf ttc woff woff2 variable
 ttf: ${FONTS}


### PR DESCRIPTION
Makes the variable font work correctly under macOS

Before this change, Regular and Italic styles were not being recognized as Fixed Width font under macOS, which means that the users of the variable version of the font could not select the "Regular" style under Terminal.app